### PR TITLE
switch from chrono to time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firebae-cm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 description = "A Firebase Cloud Messaging Http V1 implementation"
@@ -12,6 +12,6 @@ repository = "https://github.com/Vesafary/firebae-cm"
 serde =             { version = "1.0.136", features = ["derive"] }
 serde_json =        { version = "1.0.79" }
 reqwest =           { version = "0.11.9", features = ["json"], default-features=false }
-chrono =            { version = "0.4.19" }
+time =              { version = "0.3.13", features = ["formatting"] }
 log =               { version = "0.4.14" }
 thiserror =         { version = "1.0.30" }

--- a/src/notification/android.rs
+++ b/src/notification/android.rs
@@ -1,3 +1,5 @@
+use time::format_description::well_known::Rfc3339;
+
 use crate::{
     NotificationPriority,
     Visibility,
@@ -134,9 +136,9 @@ impl AndroidNotification {
         self
     }
 
-    pub fn event_time(&mut self, event_time: chrono::DateTime<chrono::Utc>) -> &mut Self {
-        self.event_time = Some(event_time.to_rfc3339());
-        self
+    pub fn event_time(&mut self, event_time: time::OffsetDateTime) -> crate::Result<&mut Self> {
+        self.event_time = Some(event_time.format(&Rfc3339)?);
+        Ok(self)
     }
 
     pub fn local_only(&mut self, local_only: bool) -> &mut Self {

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     Other(String, u16),
     #[error("{0}")]
     FcmError(#[from] FcmError),
+    #[error("{0}")]
+    TimeFormatError(#[from] time::error::Format),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
The current version of `chrono` depends on a vulnerable version of the `time` crate and no fix for this has been released yet.

https://rustsec.org/advisories/RUSTSEC-2020-0071

This pr switches over to using the `time` crate. I have increased the version to 0.2.0 since this involves changing the argument type of the `event_time` call.